### PR TITLE
Fix dev server configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --host 0.0.0.0 --port 5000",
+    "dev": "vite --host",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,20 +1,16 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const port = Number(process.env.PORT) || 5173
+
 export default defineConfig({
   plugins: [react()],
   server: {
-    host: '0.0.0.0',
-    port: 5000,
-    strictPort: true,
-    hmr: {
-      clientPort: 443,
-      protocol: 'wss'
-    }
+    host: true,
+    port,
   },
   preview: {
-    host: '0.0.0.0',
-    port: 5000,
-    strictPort: true
-  }
+    host: true,
+    port,
+  },
 })


### PR DESCRIPTION
## Summary
- allow the dev script to use Vite's default port selection instead of forcing 5000
- simplify the Vite config so the dev/preview servers respect dynamic PORT values and drop the incompatible wss HMR override

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68decec1d85c832e902882b6cfc1b524